### PR TITLE
fixing a mispelling

### DIFF
--- a/install-fedora.sh
+++ b/install-fedora.sh
@@ -27,7 +27,7 @@ then
 fi
 
 printf -- "Downloading MultiMC...\n"
-mkdir -q ~/.local/MultiMC
+mkdir -p ~/.local/MultiMC
 wget https://files.multimc.org/downloads/mmc-stable-lin64.tar.gz -O /tmp/MultiMC.tar.gz
 
 printf -- "Downloading MultiMC Icon...\n"


### PR DESCRIPTION
i assume you mean -p and not -q

-q is not a valid option for mkdir

The parents option makes it so it does not throw an error if that directory exists, so it makes sense in this case to use -p if someone has an older version of Multimc installed